### PR TITLE
Harden token verification and tracking

### DIFF
--- a/store/mem_store.go
+++ b/store/mem_store.go
@@ -54,6 +54,27 @@ func (m *MemStore) Exists(ctx context.Context, tokenID string) (*Token, error) {
 	return &tok, nil
 }
 
+func (m *MemStore) UpdateAttempts(ctx context.Context, tokenID string, attempts int) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	tok, ok := m.tokens[tokenID]
+	if !ok {
+		return fmt.Errorf("token not found")
+	}
+
+	tok.Attempts = attempts
+	m.tokens[tokenID] = tok
+
+	return nil
+}
+
 func (m *MemStore) Verify(ctx context.Context, tokenID, code string) (bool, error) {
 	select {
 	case <-ctx.Done():


### PR DESCRIPTION
## Summary
- ensure token verification and login link validation use constant-time comparisons and persist attempt counts
- add a dedicated UpdateAttempts path for token stores to avoid duplicate inserts and enforce retry limits
- harden code generation by validating configuration and removing modulo bias for large charsets

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d86e31885c832ea53021b8aa1feb4d